### PR TITLE
Make choice buttons reactive onInputOver

### DIFF
--- a/src/States/BystanderInterventionState.js
+++ b/src/States/BystanderInterventionState.js
@@ -123,6 +123,45 @@ function BystanderIntervention() {
   }
 
   /**
+   * Increases the size of a button. The intent is for this function to be used
+   * as a callback with the `button` variable "binded" to the function.
+   *
+   * ex: button1.events.onInputOver.add(increaseButtonSize.bind({button: button1}))
+   */
+  function increaseButtonSize() {
+    var sizeDelta = 10;
+
+    if (!this.button) {
+      return;
+    }
+
+    this.button.width += sizeDelta;
+    this.button.height += sizeDelta;
+
+    this.button.x -= (sizeDelta / 2);
+    this.button.y -= (sizeDelta / 2);
+  }
+
+  /**
+   * Decreases the size of a button.
+   *
+   * See increaseButtonSize() for more notes on its usage.
+   */
+  function decreaseButtonSize() {
+    var sizeDelta = 10;
+
+    if (!this.button) {
+      return;
+    }
+
+    this.button.width -= sizeDelta;
+    this.button.height -= sizeDelta;
+
+    this.button.x += (sizeDelta / 2);
+    this.button.y += (sizeDelta / 2);
+  }
+
+  /**
    * createDateDialogue: [asset key] -> void
    * adds a button to the current state, using the asset key as the image
   **/
@@ -202,13 +241,26 @@ function BystanderIntervention() {
           console.log('error in switch');
       }
 
+      // Destroying buttons to clean up references, like removing event listeners
+      if (choiceButton1) {
+        choiceButton1.destroy();
+      }
+
+      if (choiceButton2) {
+        choiceButton2.destroy();
+      }
+
       choiceButton1 = createChoiceButton1(key1);
       choiceButton1.inputEnabled = true;
       choiceButton1.events.onInputUp.add(onChoiceSelected, {selected: 1});
+      choiceButton1.events.onInputOver.add(increaseButtonSize.bind({button: choiceButton1}));
+      choiceButton1.events.onInputOut.add(decreaseButtonSize.bind({button: choiceButton1}));
 
       choiceButton2 = createChoiceButton2(key2);
       choiceButton2.inputEnabled = true;
       choiceButton2.events.onInputUp.add(onChoiceSelected, {selected: 2});
+      choiceButton2.events.onInputOver.add(increaseButtonSize.bind({button: choiceButton2}));
+      choiceButton2.events.onInputOut.add(decreaseButtonSize.bind({button: choiceButton2}));
     }
     else if (dialogueTree[progress].type == 'date') {
       dateDialogue = createDateDialogue(dialogueTree[progress].msg);

--- a/src/States/GettingReadyState.js
+++ b/src/States/GettingReadyState.js
@@ -4,12 +4,12 @@ function GettingReady() {
   var choiceButton1, choiceButton2, dateDialogue, friendDialogue;
   
   var dialogueTree = [
-    {type: 'friend', msg: 'friend1', delay: -1, duration: -1},
-    {type: 'date', msg: 'date1', delay: -1, duration: -1},
-    {type: 'date', msg: 'date2', delay: -1, duration: -1},
-    {type: 'friend', msg: 'friend2', delay: -1, duration: -1},
-    {type: 'friend', msg: 'friend3', delay: -1, duration: -1},
-    {type: 'date', msg: 'date3', delay: -1, duration: -1},
+    // {type: 'friend', msg: 'friend1', delay: -1, duration: -1},
+    // {type: 'date', msg: 'date1', delay: -1, duration: -1},
+    // {type: 'date', msg: 'date2', delay: -1, duration: -1},
+    // {type: 'friend', msg: 'friend2', delay: -1, duration: -1},
+    // {type: 'friend', msg: 'friend3', delay: -1, duration: -1},
+    // {type: 'date', msg: 'date3', delay: -1, duration: -1},
     {type: 'choice', msg: 0, delay: -1, duration: -1}, 
     ];
 
@@ -189,13 +189,35 @@ function GettingReady() {
           console.log('error in switch');
       }
 
+      if (choiceButton1) {
+        choiceButton1.destroy();
+      }
+
+      if (choiceButton2) {
+        choiceButton2.destroy();
+      }
+
       choiceButton1 = createChoiceButton1(key1);
       choiceButton1.inputEnabled = true;
       choiceButton1.events.onInputUp.add(onChoiceSelected, {selected: 1});
+      choiceButton1.events.onInputOver.add(function() {
+        choiceButton1.y += 10;
+      });
+      choiceButton1.events.onInputOut.add(function() {
+        choiceButton1.y -= 10;
+      })
 
       choiceButton2 = createChoiceButton2(key2);
       choiceButton2.inputEnabled = true;
       choiceButton2.events.onInputUp.add(onChoiceSelected, {selected: 2});
+      choiceButton2.events.onInputOver.add(function() {
+        choiceButton2.width += 10;
+        choiceButton2.height += 10;
+      });
+      choiceButton2.events.onInputOut.add(function() {
+        choiceButton2.width -= 10;
+        choiceButton2.height -= 10;
+      })
     }
     else if (dialogueTree[progress].type == 'date') {
       dateDialogue = createDateDialogue(dialogueTree[progress].msg);

--- a/src/States/GettingReadyState.js
+++ b/src/States/GettingReadyState.js
@@ -110,7 +110,10 @@ function GettingReady() {
   }
 
   /**
-   * @todo comment
+   * Increases the size of a button. The intent is for this function to be used
+   * as a callback with the `button` variable "binded" to the function.
+   *
+   * ex: button1.events.onInputOver.add(increaseButtonSize.bind({button: button1}))
    */
   function increaseButtonSize() {
     var sizeDelta = 10;
@@ -126,6 +129,11 @@ function GettingReady() {
     this.button.y -= (sizeDelta / 2);
   }
 
+  /**
+   * Decreases the size of a button.
+   *
+   * See increaseButtonSize() for more notes on its usage.
+   */
   function decreaseButtonSize() {
     var sizeDelta = 10;
 

--- a/src/States/GettingReadyState.js
+++ b/src/States/GettingReadyState.js
@@ -4,12 +4,12 @@ function GettingReady() {
   var choiceButton1, choiceButton2, dateDialogue, friendDialogue;
   
   var dialogueTree = [
-    // {type: 'friend', msg: 'friend1', delay: -1, duration: -1},
-    // {type: 'date', msg: 'date1', delay: -1, duration: -1},
-    // {type: 'date', msg: 'date2', delay: -1, duration: -1},
-    // {type: 'friend', msg: 'friend2', delay: -1, duration: -1},
-    // {type: 'friend', msg: 'friend3', delay: -1, duration: -1},
-    // {type: 'date', msg: 'date3', delay: -1, duration: -1},
+    {type: 'friend', msg: 'friend1', delay: -1, duration: -1},
+    {type: 'date', msg: 'date1', delay: -1, duration: -1},
+    {type: 'date', msg: 'date2', delay: -1, duration: -1},
+    {type: 'friend', msg: 'friend2', delay: -1, duration: -1},
+    {type: 'friend', msg: 'friend3', delay: -1, duration: -1},
+    {type: 'date', msg: 'date3', delay: -1, duration: -1},
     {type: 'choice', msg: 0, delay: -1, duration: -1}, 
     ];
 
@@ -110,6 +110,37 @@ function GettingReady() {
   }
 
   /**
+   * @todo comment
+   */
+  function increaseButtonSize() {
+    var sizeDelta = 10;
+
+    if (!this.button) {
+      return;
+    }
+
+    this.button.width += sizeDelta;
+    this.button.height += sizeDelta;
+
+    this.button.x -= (sizeDelta / 2);
+    this.button.y -= (sizeDelta / 2);
+  }
+
+  function decreaseButtonSize() {
+    var sizeDelta = 10;
+
+    if (!this.button) {
+      return;
+    }
+
+    this.button.width -= sizeDelta;
+    this.button.height -= sizeDelta;
+
+    this.button.x += (sizeDelta / 2);
+    this.button.y += (sizeDelta / 2);
+  }
+
+  /**
    * createDateDialogue: [asset key] -> void
    * adds a button to the current state, using the asset key as the image
   **/
@@ -189,6 +220,7 @@ function GettingReady() {
           console.log('error in switch');
       }
 
+      // Destroying buttons to clean up references, like removing event listeners
       if (choiceButton1) {
         choiceButton1.destroy();
       }
@@ -200,24 +232,14 @@ function GettingReady() {
       choiceButton1 = createChoiceButton1(key1);
       choiceButton1.inputEnabled = true;
       choiceButton1.events.onInputUp.add(onChoiceSelected, {selected: 1});
-      choiceButton1.events.onInputOver.add(function() {
-        choiceButton1.y += 10;
-      });
-      choiceButton1.events.onInputOut.add(function() {
-        choiceButton1.y -= 10;
-      })
+      choiceButton1.events.onInputOver.add(increaseButtonSize.bind({button: choiceButton1}));
+      choiceButton1.events.onInputOut.add(decreaseButtonSize.bind({button: choiceButton1}));
 
       choiceButton2 = createChoiceButton2(key2);
       choiceButton2.inputEnabled = true;
       choiceButton2.events.onInputUp.add(onChoiceSelected, {selected: 2});
-      choiceButton2.events.onInputOver.add(function() {
-        choiceButton2.width += 10;
-        choiceButton2.height += 10;
-      });
-      choiceButton2.events.onInputOut.add(function() {
-        choiceButton2.width -= 10;
-        choiceButton2.height -= 10;
-      })
+      choiceButton2.events.onInputOver.add(increaseButtonSize.bind({button: choiceButton2}));
+      choiceButton2.events.onInputOut.add(decreaseButtonSize.bind({button: choiceButton2}));
     }
     else if (dialogueTree[progress].type == 'date') {
       dateDialogue = createDateDialogue(dialogueTree[progress].msg);

--- a/src/States/atPromState.js
+++ b/src/States/atPromState.js
@@ -248,6 +248,15 @@ function AtProm() {
           console.log('error in switch');
       }
 
+      // Destroying buttons to clean up references, like removing event listeners
+      if (choiceButton1) {
+        choiceButton1.destroy();
+      }
+
+      if (choiceButton2) {
+        choiceButton2.destroy();
+      }
+
       choiceButton1 = createChoiceButton1(key1);
       choiceButton1.inputEnabled = true;
       choiceButton1.events.onInputUp.add(onChoiceSelected, {selected: 1});

--- a/src/States/atPromState.js
+++ b/src/States/atPromState.js
@@ -120,6 +120,45 @@ function AtProm() {
   }
 
   /**
+   * Increases the size of a button. The intent is for this function to be used
+   * as a callback with the `button` variable "binded" to the function.
+   *
+   * ex: button1.events.onInputOver.add(increaseButtonSize.bind({button: button1}))
+   */
+  function increaseButtonSize() {
+    var sizeDelta = 10;
+
+    if (!this.button) {
+      return;
+    }
+
+    this.button.width += sizeDelta;
+    this.button.height += sizeDelta;
+
+    this.button.x -= (sizeDelta / 2);
+    this.button.y -= (sizeDelta / 2);
+  }
+
+  /**
+   * Decreases the size of a button.
+   *
+   * See increaseButtonSize() for more notes on its usage.
+   */
+  function decreaseButtonSize() {
+    var sizeDelta = 10;
+
+    if (!this.button) {
+      return;
+    }
+
+    this.button.width -= sizeDelta;
+    this.button.height -= sizeDelta;
+
+    this.button.x += (sizeDelta / 2);
+    this.button.y += (sizeDelta / 2);
+  }
+
+  /**
    * createDateDialogue: [asset key] -> void
    * adds a button to the current state, using the asset key as the image
   **/
@@ -212,10 +251,14 @@ function AtProm() {
       choiceButton1 = createChoiceButton1(key1);
       choiceButton1.inputEnabled = true;
       choiceButton1.events.onInputUp.add(onChoiceSelected, {selected: 1});
+      choiceButton1.events.onInputOver.add(increaseButtonSize.bind({button: choiceButton1}));
+      choiceButton1.events.onInputOut.add(decreaseButtonSize.bind({button: choiceButton1}));
 
       choiceButton2 = createChoiceButton2(key2);
       choiceButton2.inputEnabled = true;
       choiceButton2.events.onInputUp.add(onChoiceSelected, {selected: 2});
+      choiceButton2.events.onInputOver.add(increaseButtonSize.bind({button: choiceButton2}));
+      choiceButton2.events.onInputOut.add(decreaseButtonSize.bind({button: choiceButton2}));
     }
     else if (dialogueTree[progress].type == 'date') {
       dateDialogue = createDateDialogue(dialogueTree[progress].msg);


### PR DESCRIPTION
#### What's this PR do?

When your mouse hovers over a choice button, it'll increase the size of the button by 10px.
#### Where should the reviewer start?

Code is copied and pasted and the same across all the states. This _definitely_ violates the [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself) principle. But it's a future refactor that could be done where we consolidate all common and shared functions into a single object accessible across all states.

Most of the code should be straightforward to figure out, the only one that might be tricky are the lines like....

```
choiceButton1.events.onInputOver.add(increaseButtonSize.bind({button: choiceButton1}));
```

The [bind](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/bind) function takes the object passed in as an argument and makes it the `this` var in that function.

Let me know if you have any questions about anything in here!

cc: @andrea-3000 @jmithani
