### PR TITLE
Cleaner transitions from getting-ready to at-prom to mini-game states

### DIFF
--- a/src/States/GettingReadyState.js
+++ b/src/States/GettingReadyState.js
@@ -15,6 +15,8 @@ function GettingReady() {
 
   var progress;
   var background;
+  var spriteDate;
+  var spriteFriend;
   var DIALOGUE_DISPLAY_TIME = 2000;
 
   function init() {
@@ -154,7 +156,10 @@ function GettingReady() {
   **/
 
   function createDateDialogue(key) {
-    game.add.sprite(game.world.centerX + 150, game.world.centerY - 200, 'datePic');
+    if (!spriteDate) {
+      spriteDate = game.add.sprite(game.world.centerX + 150, game.world.centerY - 200, 'datePic');
+    }
+
     return game.add.sprite(game.world.centerX - 150, game.world.centerY - 250, key);
   }
 
@@ -164,7 +169,10 @@ function GettingReady() {
   **/
 
   function createFriendDialogue(key) {
-    game.add.sprite(game.world.centerX - 350, game.world.centerY - 200, 'friendPic');
+    if (!spriteFriend) {
+      spriteFriend = game.add.sprite(game.world.centerX - 350, game.world.centerY - 200, 'friendPic');
+    }
+
     return game.add.sprite(game.world.centerX - 150, game.world.centerY - 250, key);
   }
 
@@ -304,14 +312,16 @@ function GettingReady() {
    */
   function transitionToNextState() {
     var properties = {alpha: 0};
-    var fadeOutDuration = 2000;
+    var fadeOutDuration = 1500;
     var ease = Phaser.Easing.Linear.None;
     var autoStart = true;
-    var delay = 2000;
+    var delay = 1000;
     var repeat = false;
     var yoyo = false;
 
     game.add.tween(background).to(properties, fadeOutDuration, ease, autoStart, delay, repeat, yoyo);
+    game.add.tween(spriteDate).to(properties, fadeOutDuration, ease, autoStart, delay, repeat, yoyo);
+    game.add.tween(spriteFriend).to(properties, fadeOutDuration, ease, autoStart, delay, repeat, yoyo);
     setTimeout(startNextState, fadeOutDuration + delay);
   }
 

--- a/src/States/atDanceGameState.js
+++ b/src/States/atDanceGameState.js
@@ -1,224 +1,223 @@
 function AtDanceGame() {
 
-	//board dimensions
-	var BOARD_WIDTH, BOARD_HEIGHT;
-	var background;
+  //board dimensions
+  var BOARD_WIDTH, BOARD_HEIGHT;
+  var background;
 
-	//game start/end
-	var startButton;
-	var paused;
+  //game start/end
+  var startButton;
+  var paused;
 
-	//table
-	var tableCount;
-	var tables;
-	var tableDialogue
+  //table
+  var tableCount;
+  var tables;
+  var tableDialogue
 
-	//enemies
-	var enemyCount;
-	var enemies;
-	var enemyDialogue = ['enemyDialogue1', 'enemyDialogue2', 'enemyDialogue3'];
+  //enemies
+  var enemyCount;
+  var enemies;
+  var enemyDialogue = ['enemyDialogue1', 'enemyDialogue2', 'enemyDialogue3'];
 
-	//player
-	var player;
+  //player
+  var player;
 
-	//items
-	var item1;
-	var item2;
-	var item3;
-	var dialogue;
+  //items
+  var item1;
+  var item2;
+  var item3;
+  var dialogue;
 
-	function init() {
-		BOARD_HEIGHT = 600;
-		BOARD_WIDTH = 800;
+  function init() {
+    BOARD_HEIGHT = 600;
+    BOARD_WIDTH = 800;
 
-		paused = true;
-		startButton = null;
+    paused = true;
+    startButton = null;
 
-		//table
-		tables = null;
-		tableCount = 6;
+    //table
+    tables = null;
+    tableCount = 6;
 
-		//enemycouples
-		enemies = null;
-		enemyCount = 5;
-	}
+    //enemycouples
+    enemies = null;
+    enemyCount = 5;
+  }
 
-	function preload() {
-		//background
-		game.load.image('background', 'assets/Backgrounds/ADG_background.png');
+  function preload() {
+    //background
+    game.load.image('background', 'assets/Backgrounds/ADG_background.png');
 
-		game.load.image('startButtonImg', 'assets/mini-game/ADG_startButton.png');
+    game.load.image('startButtonImg', 'assets/mini-game/ADG_startButton.png');
 
-		game.load.image('tableImg', 'assets/mini-game/ADG_table.png');
-		game.load.image('enemyImg', 'assets/mini-game/ADG_couple.png')
-		game.load.image('playerImg', 'assets/mini-game/ADG_player.png');
+    game.load.image('tableImg', 'assets/mini-game/ADG_table.png');
+    game.load.image('enemyImg', 'assets/mini-game/ADG_couple.png')
+    game.load.image('playerImg', 'assets/mini-game/ADG_player.png');
 
-		game.load.image('itemImg1', 'assets/mini-game/ADG_bowtie.png');
-		game.load.image('itemImg2', 'assets/mini-game/ADG_corsage.png');
-		game.load.image('itemImg3', 'assets/mini-game/ADG_purse.png');
+    game.load.image('itemImg1', 'assets/mini-game/ADG_bowtie.png');
+    game.load.image('itemImg2', 'assets/mini-game/ADG_corsage.png');
+    game.load.image('itemImg3', 'assets/mini-game/ADG_purse.png');
 
-		//item dialogue
-		game.load.image('itemDialogue1', 'assets/mini-game/ADG_itemDialogue1.png');
-		game.load.image('itemDialogue2', 'assets/mini-game/ADG_itemDialogue2.png');
-		game.load.image('itemDialogue3', 'assets/mini-game/ADG_itemDialogue3.png');
+    //item dialogue
+    game.load.image('itemDialogue1', 'assets/mini-game/ADG_itemDialogue1.png');
+    game.load.image('itemDialogue2', 'assets/mini-game/ADG_itemDialogue2.png');
+    game.load.image('itemDialogue3', 'assets/mini-game/ADG_itemDialogue3.png');
 
-		//enemy, table collision dialogue
-		game.load.image('enemyDialogue1', 'assets/mini-game/enemyDialogue1.png');
-		game.load.image('enemyDialogue2', 'assets/mini-game/enemyDialogue2.png');
-		game.load.image('enemyDialogue3', 'assets/mini-game/enemyDialogue3.png');
-		game.load.image('tableDialogue', 'assets/ADG_couple.png');
-	}
+    //enemy, table collision dialogue
+    game.load.image('enemyDialogue1', 'assets/mini-game/enemyDialogue1.png');
+    game.load.image('enemyDialogue2', 'assets/mini-game/enemyDialogue2.png');
+    game.load.image('enemyDialogue3', 'assets/mini-game/enemyDialogue3.png');
+    game.load.image('tableDialogue', 'assets/mini-game/ADG_couple.png');
+  }
 
-	function create() {
-		game.physics.startSystem(Phaser.Physics.ARCADE);
+  function create() {
+    game.physics.startSystem(Phaser.Physics.ARCADE);
 
-		background = game.add.tileSprite(0, 0, 800, 600, 'background');
-		
-		//draws tables
-		tables = game.add.group();
-		tables.name = 'tables';
-		tables.enableBody = true;
+    background = game.add.tileSprite(0, 0, 800, 600, 'background');
+    
+    //draws tables
+    tables = game.add.group();
+    tables.name = 'tables';
+    tables.enableBody = true;
 
-		//generating tables
-		var tableX = 100;
-		var tableY = 100;
-		for (var i = 0; i < tableCount; i ++) {
-			if (i == 3) {
-				tableY = 400;
-				tableX = 100;
-			}
-			var table = tables.create(tableX, tableY, 'tableImg');
-			table.body.collideWorldBounds = true;
-			table.body.immovable = true;
-			tableX += 225;
-		}
+    //generating tables
+    var tableX = 100;
+    var tableY = 100;
+    for (var i = 0; i < tableCount; i ++) {
+      if (i == 3) {
+        tableY = 400;
+        tableX = 100;
+      }
+      var table = tables.create(tableX, tableY, 'tableImg');
+      table.body.collideWorldBounds = true;
+      table.body.immovable = true;
+      tableX += 225;
+    }
 
-		//enemies
-		enemies = game.add.group();
-		enemies.name = 'enemies';
-		enemies.enableBody = true;
+    //enemies
+    enemies = game.add.group();
+    enemies.name = 'enemies';
+    enemies.enableBody = true;
 
-		for (var i = 0; i < enemyCount; i++) {
-			var couple = enemies.create(game.rnd.realInRange(0, BOARD_WIDTH), game.rnd.realInRange(0, BOARD_HEIGHT-25), 'enemyImg');
-			couple.body.collideWorldBounds = true;
-			couple.body.allowGravity = false;
-			couple.body.bounce.setTo(1,1);
-			couple.body.velocity.setTo(0);
-		}
+    for (var i = 0; i < enemyCount; i++) {
+      var couple = enemies.create(game.rnd.realInRange(0, BOARD_WIDTH), game.rnd.realInRange(0, BOARD_HEIGHT-25), 'enemyImg');
+      couple.body.collideWorldBounds = true;
+      couple.body.allowGravity = false;
+      couple.body.bounce.setTo(1,1);
+      couple.body.velocity.setTo(0);
+    }
 
-		//generating items
-		item1 = game.add.sprite(250, 100, 'itemImg1');
-		game.physics.arcade.enable(item1);
-		item2 = game.add.sprite(550, 200, 'itemImg2');
-		game.physics.arcade.enable(item2);
-		item3 = game.add.sprite(300, 300, 'itemImg3');
-		game.physics.arcade.enable(item3);
+    //generating items
+    item1 = game.add.sprite(250, 100, 'itemImg1');
+    game.physics.arcade.enable(item1);
+    item2 = game.add.sprite(550, 200, 'itemImg2');
+    game.physics.arcade.enable(item2);
+    item3 = game.add.sprite(300, 300, 'itemImg3');
+    game.physics.arcade.enable(item3);
 
-		//draws player
-		player = game.add.sprite(10, BOARD_HEIGHT/2 - 12.5, 'playerImg');
-		player.name = 'player';
-		game.physics.arcade.enable(player);
-		player.body.allowGravity = false;
-		player.body.collideWorldBounds = true;
-		player.body.bounce.setTo(200,200);
-		player.body.velocity = 3;
+    //draws player
+    player = game.add.sprite(10, BOARD_HEIGHT/2 - 12.5, 'playerImg');
+    player.name = 'player';
+    game.physics.arcade.enable(player);
+    player.body.allowGravity = false;
+    player.body.collideWorldBounds = true;
+    player.body.bounce.setTo(200,200);
+    player.body.velocity = 3;
 
-		//start button
-		startButton = game.add.button(game.world.centerX - game.cache.getImage('startButtonImg').width/2, game.world.centerY - game.cache.getImage('startButtonImg').height/2, 'startButtonImg', null, null, 2, 1, 0);
-		startButton.inputEnabled = true;
-		startButton.events.onInputUp.add(actionOnClick, {selected: 1});
-	}
+    //start button
+    startButton = game.add.button(game.world.centerX - game.cache.getImage('startButtonImg').width/2, game.world.centerY - game.cache.getImage('startButtonImg').height/2, 'startButtonImg', null, null, 2, 1, 0);
+    startButton.inputEnabled = true;
+    startButton.events.onInputUp.add(actionOnClick, {selected: 1});
+  }
 
-	function update() {
-		//item disappears when touched and brings up dialogue
-		game.physics.arcade.collide(player, item1, touchItem, null, {type: 'item', itemPickedUp: item1, dialogueName: 'itemDialogue1'});
-		game.physics.arcade.collide(player, item2, touchItem, null, {type: 'item', itemPickedUp: item2, dialogueName: 'itemDialogue2'});
-		game.physics.arcade.collide(player, item3, touchItem, null, {itemPickedUp: item3, dialogueName: 'itemDialogue3'});
+  function update() {
+    //item disappears when touched and brings up dialogue
+    game.physics.arcade.collide(player, item1, touchItem, null, {type: 'item', itemPickedUp: item1, dialogueName: 'itemDialogue1'});
+    game.physics.arcade.collide(player, item2, touchItem, null, {type: 'item', itemPickedUp: item2, dialogueName: 'itemDialogue2'});
+    game.physics.arcade.collide(player, item3, touchItem, null, {itemPickedUp: item3, dialogueName: 'itemDialogue3'});
 
-		game.physics.arcade.overlap(player, item1, touchItem, null, {type: 'item', itemPickedUp: item1, dialogueName: 'itemDialogue1'});
-		game.physics.arcade.overlap(player, item2, touchItem, null, {type: 'item', itemPickedUp: item2, dialogueName: 'itemDialogue2'});
-		game.physics.arcade.overlap(player, item3, touchItem, null, {type: 'item', itemPickedUp: item3, dialogueName: 'itemDialogue3'});
+    game.physics.arcade.overlap(player, item1, touchItem, null, {type: 'item', itemPickedUp: item1, dialogueName: 'itemDialogue1'});
+    game.physics.arcade.overlap(player, item2, touchItem, null, {type: 'item', itemPickedUp: item2, dialogueName: 'itemDialogue2'});
+    game.physics.arcade.overlap(player, item3, touchItem, null, {type: 'item', itemPickedUp: item3, dialogueName: 'itemDialogue3'});
 
-		//checks table collisions
-		game.physics.arcade.collide(player, tables, touchItem, null, {type: 'table', itemPickedUp: tables, dialogueName: 'tableDialogue'});
-		game.physics.arcade.overlap(player, tables, touchItem, null, {type: 'table', itemPickedUp: enemies, dialogueName: 'tableDialogue'});
+    //checks table collisions
+    game.physics.arcade.collide(player, tables, touchItem, null, {type: 'table', itemPickedUp: tables, dialogueName: 'tableDialogue'});
+    game.physics.arcade.overlap(player, tables, touchItem, null, {type: 'table', itemPickedUp: enemies, dialogueName: 'tableDialogue'});
 
-		//checks enemy collisions
-		game.physics.arcade.collide(player, enemies, touchItem, null, 
-			{type: 'enemy', itemPickedUp: enemyDialogue, dialogueName: enemyDialogue[between(0, 2)]});
-		//game.physics.arcade.overlap(player, enemies, touchItem, null, {type: 'enemy', itemPickedUp: enemyDialogue, dialogueName: 'enemyDialogue'});
+    //checks enemy collisions
+    game.physics.arcade.collide(player, enemies, touchItem, null, {type: 'enemy', itemPickedUp: enemyDialogue, dialogueName: 'enemyDialogue'});
+    //game.physics.arcade.overlap(player, enemies, touchItem, null, {type: 'enemy', itemPickedUp: enemyDialogue, dialogueName: 'enemyDialogue'});
 
-		game.physics.arcade.collide(enemies, tables);
-		game.physics.arcade.overlap(enemies, tables);
+    game.physics.arcade.collide(enemies, tables);
+    game.physics.arcade.overlap(enemies, tables);
 
-		if (!paused) {
-			//updates enemy movement
-			updateEnemies();
+    if (!paused) {
+      //updates enemy movement
+      updateEnemies();
 
-			//updates player movement
-			updatePlayer();	
-		}
-	}
+      //updates player movement
+      updatePlayer();
+    }
+  }
 
-	function shutdown() {
-		player.destroy();
-		tables.destroy();
-		enemies.destroy();
-	}
+  function shutdown() {
+    player.destroy();
+    tables.destroy();
+    enemies.destroy();
+  }
 
-	function updateEnemies() {
-		enemies.forEach(function(couple) {
-			couple.angle+=5;
-		}, this);
-	}
+  function updateEnemies() {
+    enemies.forEach(function(couple) {
+      couple.angle+=5;
+    }, this);
+  }
 
-	function updatePlayer() {
-		//mouse following
-		var yDistance = game.input.mousePointer.y - player.y;
-		var xDistance = game.input.mousePointer.x - player.x;
-		if (Math.sqrt(yDistance*yDistance +  xDistance*xDistance) < player.body.velocity) {
-			//prevents jitter when sprite is at mouse location
-			player.x = game.input.mousePointer.x;
-			player.y = game.input.mousePointer.y;
-		} else {
-			//points sprite in direction of mouse and moves it based on speed
-			var directionAngle = game.math.angleBetween(player.x, player.y, game.input.mousePointer.x, game.input.mousePointer.y);
-			player.angle = directionAngle * 180 / Math.PI;
-			player.x += Math.cos(directionAngle) * player.body.velocity;
-			player.y += Math.sin(directionAngle) * player.body.velocity;
-		}
-	}
+  function updatePlayer() {
+    //mouse following
+    var yDistance = game.input.mousePointer.y - player.y;
+    var xDistance = game.input.mousePointer.x - player.x;
+    if (Math.sqrt(yDistance*yDistance +  xDistance*xDistance) < player.body.velocity) {
+      //prevents jitter when sprite is at mouse location
+      player.x = game.input.mousePointer.x;
+      player.y = game.input.mousePointer.y;
+    } else {
+      //points sprite in direction of mouse and moves it based on speed
+      var directionAngle = game.math.angleBetween(player.x, player.y, game.input.mousePointer.x, game.input.mousePointer.y);
+      player.angle = directionAngle * 180 / Math.PI;
+      player.x += Math.cos(directionAngle) * player.body.velocity;
+      player.y += Math.sin(directionAngle) * player.body.velocity;
+    }
+  }
 
-	function touchItem() {
-		if (this.type == 'item') {
-			this.itemPickedUp.kill();
-		}
-		game.paused = true;
-		dialogue = game.add.sprite(game.width/2, game.height/4, this.dialogueName);
-		setTimeout(killDialogue, 2000);
-		if (this.type != 'item') {
-			player.x -= 5;
-			player.y -= 5;
-		}
-	}
+  function touchItem() {
+    if (this.type == 'item') {
+      this.itemPickedUp.kill();
+    }
+    game.paused = true;
+    dialogue = game.add.sprite(game.width/2, game.height/4, this.dialogueName);
+    setTimeout(killDialogue, 2000);
+    if (this.type != 'item') {
+      player.x -= 5;
+      player.y -= 5;
+    }
+  }
 
-	function killDialogue() {
-		game.paused = false;
-		dialogue.kill();
-		dialogue = null;
-	}
+  function killDialogue() {
+    game.paused = false;
+    dialogue.kill();
+    dialogue = null;
+  }
 
-	function actionOnClick() {
-		paused = false;
-		enemies.forEach(function(couple) { couple.body.velocity.setTo(200); }, this);
-		startButton.kill();
-		startButton = null;
-	}
+  function actionOnClick() {
+    paused = false;
+    enemies.forEach(function(couple) { couple.body.velocity.setTo(200); }, this);
+    startButton.kill();
+    startButton = null;
+  }
 
-	return {
-		init: init,
-		preload: preload,
-		create: create,
-		update: update
-	}
+  return {
+    init: init,
+    preload: preload,
+    create: create,
+    update: update
+  }
 }

--- a/src/States/atDanceGameState.js
+++ b/src/States/atDanceGameState.js
@@ -26,6 +26,7 @@ function AtDanceGame() {
   var item2;
   var item3;
   var dialogue;
+  var itemsCount;
 
   function init() {
     BOARD_HEIGHT = 600;
@@ -107,6 +108,7 @@ function AtDanceGame() {
     }
 
     //generating items
+    itemsCount = 3;
     item1 = game.add.sprite(250, 100, 'itemImg1');
     game.physics.arcade.enable(item1);
     item2 = game.add.sprite(550, 200, 'itemImg2');
@@ -191,6 +193,13 @@ function AtDanceGame() {
   function touchItem() {
     if (this.type == 'item') {
       this.itemPickedUp.kill();
+      itemsCount--;
+
+      // If all items have been picked up, move onto next state once the
+      // dialogue box has been killed. See setTimeout(killDialogue) below.
+      if (itemsCount <= 0) {
+        setTimeout(transitionToNextState, 2000);
+      }
     }
     game.paused = true;
     dialogue = game.add.sprite(game.width/2, game.height/4, this.dialogueName);
@@ -212,6 +221,33 @@ function AtDanceGame() {
     enemies.forEach(function(couple) { couple.body.velocity.setTo(200); }, this);
     startButton.kill();
     startButton = null;
+  }
+
+  /**
+   * Begin transition to the next state with a fade out.
+   */
+  function transitionToNextState() {
+    var properties = {alpha: 0};
+    var fadeOutDuration = 2000;
+    var ease = Phaser.Easing.Linear.None;
+    var autoStart = true;
+    var delay = 2000;
+    var repeat = false;
+    var yoyo = false;
+
+    game.add.tween(background).to(properties, fadeOutDuration, ease, autoStart, delay, repeat, yoyo);
+    game.add.tween(enemies).to(properties, fadeOutDuration, ease, autoStart, delay, repeat, yoyo);
+    game.add.tween(player).to(properties, fadeOutDuration, ease, autoStart, delay, repeat, yoyo);
+    game.add.tween(tables).to(properties, fadeOutDuration, ease, autoStart, delay, repeat, yoyo);
+    setTimeout(startNextState, fadeOutDuration + delay);
+  }
+
+  /**
+   * Add and start next state. Starting a new state automatically shuts down the current one.
+   */
+  function startNextState() {
+    game.state.add('bystander-intervention', new BystanderIntervention());
+    game.state.start('bystander-intervention');
   }
 
   return {

--- a/src/States/atDanceGameState.js
+++ b/src/States/atDanceGameState.js
@@ -148,7 +148,8 @@ function AtDanceGame() {
     game.physics.arcade.overlap(player, tables, touchItem, null, {type: 'table', itemPickedUp: enemies, dialogueName: 'tableDialogue'});
 
     //checks enemy collisions
-    game.physics.arcade.collide(player, enemies, touchItem, null, {type: 'enemy', itemPickedUp: enemyDialogue, dialogueName: 'enemyDialogue'});
+    game.physics.arcade.collide(player, enemies, touchItem, null,
+      {type: 'enemy', itemPickedUp: enemyDialogue, dialogueName: enemyDialogue[game.rnd.between(0, 2)]});
     //game.physics.arcade.overlap(player, enemies, touchItem, null, {type: 'enemy', itemPickedUp: enemyDialogue, dialogueName: 'enemyDialogue'});
 
     game.physics.arcade.collide(enemies, tables);
@@ -204,7 +205,8 @@ function AtDanceGame() {
       }
     }
     game.paused = true;
-    dialogue = game.add.sprite(game.width/2, game.height/4, this.dialogueName);
+    // 350 and 100 are half the size of the dialogue asset
+    dialogue = game.add.sprite(game.world.centerX - 350, game.world.centerY - 100, this.dialogueName);
     setTimeout(killDialogue, 2000);
     if (this.type != 'item') {
       player.x -= 5;

--- a/src/States/atDanceGameState.js
+++ b/src/States/atDanceGameState.js
@@ -222,5 +222,3 @@ function AtDanceGame() {
 		update: update
 	}
 }
-
-game.state.add('at-mini-game', new AtDanceGame());

--- a/src/States/atDanceGameState.js
+++ b/src/States/atDanceGameState.js
@@ -129,6 +129,8 @@ function AtDanceGame() {
     startButton = game.add.button(game.world.centerX - game.cache.getImage('startButtonImg').width/2, game.world.centerY - game.cache.getImage('startButtonImg').height/2, 'startButtonImg', null, null, 2, 1, 0);
     startButton.inputEnabled = true;
     startButton.events.onInputUp.add(actionOnClick, {selected: 1});
+    startButton.events.onInputOver.add(increaseButtonSize.bind({button: startButton}));
+    startButton.events.onInputOut.add(decreaseButtonSize.bind({button: startButton}));
   }
 
   function update() {
@@ -221,6 +223,45 @@ function AtDanceGame() {
     enemies.forEach(function(couple) { couple.body.velocity.setTo(200); }, this);
     startButton.kill();
     startButton = null;
+  }
+
+  /**
+   * Increases the size of a button. The intent is for this function to be used
+   * as a callback with the `button` variable "binded" to the function.
+   *
+   * ex: button1.events.onInputOver.add(increaseButtonSize.bind({button: button1}))
+   */
+  function increaseButtonSize() {
+    var sizeDelta = 10;
+
+    if (!this.button) {
+      return;
+    }
+
+    this.button.width += sizeDelta;
+    this.button.height += sizeDelta;
+
+    this.button.x -= (sizeDelta / 2);
+    this.button.y -= (sizeDelta / 2);
+  }
+
+  /**
+   * Decreases the size of a button.
+   *
+   * See increaseButtonSize() for more notes on its usage.
+   */
+  function decreaseButtonSize() {
+    var sizeDelta = 10;
+
+    if (!this.button) {
+      return;
+    }
+
+    this.button.width -= sizeDelta;
+    this.button.height -= sizeDelta;
+
+    this.button.x += (sizeDelta / 2);
+    this.button.y += (sizeDelta / 2);
   }
 
   /**

--- a/src/States/atDanceGameState.js
+++ b/src/States/atDanceGameState.js
@@ -235,6 +235,10 @@ function AtDanceGame() {
     var repeat = false;
     var yoyo = false;
 
+    // Disable physics on the player object
+    player.body.enable = false;
+
+    // Fade out sprites
     game.add.tween(background).to(properties, fadeOutDuration, ease, autoStart, delay, repeat, yoyo);
     game.add.tween(enemies).to(properties, fadeOutDuration, ease, autoStart, delay, repeat, yoyo);
     game.add.tween(player).to(properties, fadeOutDuration, ease, autoStart, delay, repeat, yoyo);

--- a/src/States/atPromState.js
+++ b/src/States/atPromState.js
@@ -2,6 +2,9 @@ function AtProm() {
 
   // These are the actual sprites and buttons that will be created and destroyed as the dialogue progresses
   var choiceButton1, choiceButton2, dateDialogue, friendDialogue, narrative;
+  var spriteDate;
+  var spriteFriend;
+  var spriteBackground;
   
   var dialogueTree = [
     {type: 'narrative', msg: 'narrative1', delay: -1, duration: -1},
@@ -82,7 +85,7 @@ function AtProm() {
     console.log('in create');
 
     //game.stage.backgroundColor = 'background';
-    game.add.tileSprite(0, 0, 800, 600, 'background');
+    spriteBackground = game.add.tileSprite(0, 0, 800, 600, 'background');
 
     //game.add.sprite(game.world.centerX - 350, game.world.centerY - 200, 'friendPic');
     //game.add.sprite(game.world.centerX + 150, game.world.centerY - 200, 'datePic');
@@ -164,7 +167,10 @@ function AtProm() {
   **/
 
   function createDateDialogue(key) {
-    game.add.sprite(game.world.centerX + 150, game.world.centerY - 200, 'datePic');
+    if (!spriteDate) {
+      spriteDate = game.add.sprite(game.world.centerX + 150, game.world.centerY - 200, 'datePic');
+    }
+
     return game.add.sprite(game.world.centerX - 150, game.world.centerY - 250, key);
   }
 
@@ -174,7 +180,10 @@ function AtProm() {
   **/
 
   function createFriendDialogue(key) {
-    game.add.sprite(game.world.centerX - 350, game.world.centerY - 200, 'friendPic');
+    if (!spriteFriend) {
+      spriteFriend = game.add.sprite(game.world.centerX - 350, game.world.centerY - 200, 'friendPic');
+    }
+
     return game.add.sprite(game.world.centerX - 150, game.world.centerY - 250, key);
   }
 
@@ -209,7 +218,10 @@ function AtProm() {
       narrative.destroy();
     }
 
-    if (dialogueTree[progress].type == 'choice') {
+    if (progress >= dialogueTree.length) {
+      transitionToNextState();
+    }
+    else if (dialogueTree[progress].type == 'choice') {
 
       //checking for correct player choice dialogue buttons
       switch(dialogueTree[progress].msg) {
@@ -327,6 +339,32 @@ function AtProm() {
 
     // Display the next dialogue
     displayNext();
+  }
+
+  /**
+   * Begin transition to the next state with a fade out.
+   */
+  function transitionToNextState() {
+    var properties = {alpha: 0};
+    var fadeOutDuration = 1500;
+    var ease = Phaser.Easing.Linear.None;
+    var autoStart = true;
+    var delay = 1000;
+    var repeat = false;
+    var yoyo = false;
+
+    game.add.tween(spriteBackground).to(properties, fadeOutDuration, ease, autoStart, delay, repeat, yoyo);
+    game.add.tween(spriteDate).to(properties, fadeOutDuration, ease, autoStart, delay, repeat, yoyo);
+    game.add.tween(spriteFriend).to(properties, fadeOutDuration, ease, autoStart, delay, repeat, yoyo);
+    setTimeout(startNextState, fadeOutDuration + delay);
+  }
+
+  /**
+   * Add and start next state. Starting a new state automatically shuts down the current one.
+   */
+  function startNextState() {
+    game.state.add('at-mini-game', new AtDanceGame());
+    game.state.start('at-mini-game');
   }
 
   return {


### PR DESCRIPTION
#### What's this PR do?

Transitions added between at-prom to mini-game to bystander-intervention.

Transitions were also made a little cleaner so all sprites on the screen would fade out along with the background.

And then atDanceGameState.js looks like a lot has changed, but that's mostly just because I changed the indents from tabs to spaces to match the rest of our codebase.
#### Where should the reviewer start?
- Anywhere you see a `game.add.tween` is where the fade out of a sprite is happening. In some places I had to add member variables to the states so that I'd have a reference to the sprite I wanted to fade out at the end of a state.
- This block in `touchItem()` of `AtDanceGame` is what determines when to transition out of the mini game.

```
itemsCount--;

// If all items have been picked up, move onto next state once the
// dialogue box has been killed. See setTimeout(killDialogue) below.
if (itemsCount <= 0) {
  setTimeout(transitionToNextState, 2000);
}
```
#### What are the relevant tickets?

Closes #10
Closes #16

cc: @andrea-3000 @jmithani 
