### PR TITLE
Dancing game fixes

### DIFF
--- a/src/States/atDanceGameState.js
+++ b/src/States/atDanceGameState.js
@@ -103,6 +103,7 @@ function AtDanceGame() {
 
     for (var i = 0; i < enemyCount; i++) {
       var couple = enemies.create(game.rnd.realInRange(0, BOARD_WIDTH), game.rnd.realInRange(0, BOARD_HEIGHT-25), 'enemyImg');
+      couple.anchor.setTo(0.5, 0.5);
       couple.body.collideWorldBounds = true;
       couple.body.allowGravity = false;
       couple.body.bounce.setTo(1,1);
@@ -121,11 +122,12 @@ function AtDanceGame() {
     //draws player
     player = game.add.sprite(10, BOARD_HEIGHT/2 - 12.5, 'playerImg');
     player.name = 'player';
+    player.anchor.setTo(0.5,0.5);
     game.physics.arcade.enable(player);
     player.body.allowGravity = false;
     player.body.collideWorldBounds = true;
     player.body.bounce.setTo(200,200);
-    player.body.velocity = 3;
+    player.body.velocity.setTo(0,0);
 
     //start button
     startButton = game.add.button(game.world.centerX - game.cache.getImage('startButtonImg').width/2, game.world.centerY - game.cache.getImage('startButtonImg').height/2, 'startButtonImg', null, null, 2, 1, 0);
@@ -155,10 +157,6 @@ function AtDanceGame() {
     game.physics.arcade.collide(player, enemies, touchItem, null,
       {type: 'enemy', itemPickedUp: enemyDialogue, dialogueName: enemyDialogue[game.rnd.between(0, 2)], duration: 2000});
 
-    //@todo:change it so the enemy dialogue chooses randomly for each individual collision 
-
-    //game.physics.arcade.overlap(player, enemies, touchItem, null, {type: 'enemy', itemPickedUp: enemyDialogue, dialogueName: 'enemyDialogue'});
-
     game.physics.arcade.collide(enemies, tables);
     game.physics.arcade.overlap(enemies, tables);
 
@@ -184,20 +182,12 @@ function AtDanceGame() {
   }
 
   function updatePlayer() {
-    //mouse following
-    var yDistance = game.input.mousePointer.y - player.y;
-    var xDistance = game.input.mousePointer.x - player.x;
-    if (Math.sqrt(yDistance*yDistance +  xDistance*xDistance) < player.body.velocity) {
-      //prevents jitter when sprite is at mouse location
-      player.x = game.input.mousePointer.x;
-      player.y = game.input.mousePointer.y;
-    } else {
-      //points sprite in direction of mouse and moves it based on speed
-      var directionAngle = game.math.angleBetween(player.x, player.y, game.input.mousePointer.x, game.input.mousePointer.y);
-      player.angle = directionAngle * 180 / Math.PI;
-      player.x += Math.cos(directionAngle) * player.body.velocity;
-      player.y += Math.sin(directionAngle) * player.body.velocity;
+    // mouse following
+    game.physics.arcade.moveToPointer(player, 250);
+    if (Phaser.Rectangle.contains(player.body, game.input.x, game.input.y)) {
+      player.body.velocity.setTo(0, 0);
     }
+    player.angle += 5;
   }
 
   function touchItem() {


### PR DESCRIPTION
#### What's this PR do?

Improvements to dancing movement and collision.
##### Changing movement to use the arcade.moveToPointer

`moveToPointer` didn't work before because of this line:

```
player.body.velocity = 3;
```

The `velocity` var is actually suppose to be an object. If you follow the `moveToPointer` code, you'll see it can't set the velocity because it's not an object and so the sprite doesn't move.  I end up just setting velocity to 0 with `setTo(0, 0)` and let `moveToPointer` handle it in `updatePlayer`.
##### Sprites anchored to rotate around middle

I tried to have physics bodies rotate the same way the sprites previously did. But Arcade physics has [axis aligned bounding boxes](http://www.html5gamedevs.com/topic/6585-rotate-sprite-body-along-with-sprite-angle/) which won't let that happen.

So we're just rotating around the middle of the sprites now. The two spots you see `.anchor.setTo(0.5, 0.5)`, that's what I'm doing there.
